### PR TITLE
Update tests to pass in collection instead of single instance

### DIFF
--- a/spec/views/invoices_index_view_spec.rb
+++ b/spec/views/invoices_index_view_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe "invoices_index_view" do
   end
 
   it "renders the invoice partial" do
-    invoices = Invoice.first
+    invoices = Invoice.first(1)
     assign(:invoices, invoices)
     render :template => "invoices/index.html.erb"
     expect(rendered).to render_template(:partial => "invoices/_invoice")
   end
 
   it "renders the invoice partial using the abstract method of rendering collection" do
-    invoices = Invoice.first
+    invoices = Invoice.first(1)
     assign(:invoices, invoices)
     expect_any_instance_of(Invoice).to receive(:to_partial_path).and_call_original
     render :template => "invoices/index.html.erb"

--- a/spec/views/orders_index_view_spec.rb
+++ b/spec/views/orders_index_view_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe "orders_index_view" do
   end
 
   it "renders the order partial" do
-    orders = Order.first
+    orders = Order.first(1)
     assign(:orders, orders)
     render :template => "orders/index.html.erb"
     expect(rendered).to render_template(:partial => "orders/_order")
   end
 
   it "renders the order partial using the abstract method of rendering collection" do
-    orders = Order.first
+    orders = Order.first(1)
     assign(:orders, orders)
     expect_any_instance_of(Order).to receive(:to_partial_path).and_call_original
     render :template => "orders/index.html.erb"


### PR DESCRIPTION
The problem:
The index pages are expecting `@invoices` and `@orders` to be collections, but the tests set them to equal `Invoice.first` and `Order.first`. This means that the tests fail with messages `undefined method `each' for #<Invoice:0x00007f80b0cd17b0>` and `undefined method `each' for #<Order:0x00007f80b16ab2e0>`.  The point of this lab is to refactor working code, not to debug why the tests are behaving differently from the `index` controller actions for Invoice and Order.

The solution:
Modify the tests so they set `@invoices` to `Invoice.first(1)` and `@orders` to `Order.first(1)`.  This way the variables are collections containing a single instance each, rather than just single instances (which are not iterable).

Closes #3 

#staff